### PR TITLE
Add a `k` (Kill) letter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The `o` method takes options, too, so you can add a prefix message to the output
 - `e` (Empty)        raises a Letters::EmptyError if its receiver is empty
 - `f` (File)         writes its receiver into a file in a given format
 - `j` (Jump)         executes its block in the context of its receiver
+- `k` (Kill)         raises Letters::KillError after a maximum number of calls
 - `l` (Logger)       logs its receivers on the available logger instance
 - `m` (Taint)        taints (or untaints) its receiver
 - `n` (Nil)          raises a Letters::NilError if its receiver is nil

--- a/lib/letters/core_ext.rb
+++ b/lib/letters/core_ext.rb
@@ -2,6 +2,7 @@ require "letters/helpers"
 require "letters/diff"
 require "letters/assertion_error"
 require "letters/empty_error"
+require "letters/kill_error"
 require "letters/nil_error"
 require "letters/time_formats"
 
@@ -90,6 +91,19 @@ module Letters
     def j(&block)
       tap do |o|
         o.instance_eval &block
+      end
+    end
+
+    # Kill
+    def k(opts={})
+      opts = { max: 0 }.merge(opts)
+      opts.merge! :error_class => KillError
+      tap do |o|
+        @letters_kill_count ||= 0
+        if @letters_kill_count >= opts[:max]
+          raise opts[:error_class]
+        end
+        @letters_kill_count += 1
       end
     end
 

--- a/lib/letters/kill_error.rb
+++ b/lib/letters/kill_error.rb
@@ -1,0 +1,4 @@
+module Letters
+  class KillError < RuntimeError 
+  end
+end

--- a/spec/letters/core_ext_spec.rb
+++ b/spec/letters/core_ext_spec.rb
@@ -15,7 +15,7 @@ module Letters
       FileUtils.rm_rf "tmp"
     end
 
-    it "all letter methods but #e and #n return the original object" do
+    it "all letter methods but #e, #k and #n return the original object" do
       # Prevent output and debugging
       Helpers.should_receive(:call_debugger).any_number_of_times
       $stdout.should_receive(:puts).any_number_of_times
@@ -23,7 +23,7 @@ module Letters
       Helpers.should_receive(:change_safety).any_number_of_times
 
       ("a".."z").to_a.reject do |letter|
-        letter =~ /[ejn]/
+        letter =~ /[ekjn]/
       end.select do |letter|
         hash.respond_to? letter
       end.each do |letter|
@@ -143,6 +143,24 @@ module Letters
       it "allows for IO, even in object context" do
         $stdout.should_receive(:puts).with(0)
         hash.j { puts count }
+      end
+    end
+
+    describe "#k (kill)" do
+      it 'raises a KillError immediately by default' do
+        lambda { hash.k }.should raise_error(KillError)
+      end
+
+      it 'does not raises if number of calls are below max' do
+        lambda{ hash.k(max: 1) }.should_not raise_error
+      end
+
+      it 'raises a KillError if number of calls is above max' do
+        h, count = hash, 0
+        lambda{
+          10.times{ h.k(max: 5); count += 1; }
+        }.should raise_error(KillError)
+        count.should eq(5)
       end
     end
 


### PR DESCRIPTION
Somewhat similar to #4 (q for Quit), but this one accepts a `max` that specifies a maximal number of calls before raising a KillError.

I wrote this one this morning while debugging an infinite recursion (SystemStackTrace), which proved difficult to debug, because happening in rspec tests. A typical use could be:

```
def visit(*)
  k(max: 3)
  ... visit(*) ... # unbounded recursion
end
```

The KillError naturally shows the stacktrace of the last 3 calls, which proved very nice for fixing my stuff this morning. In my case, since the `visit` method was not called on the same instance, I used the following trick:

```
def visit(*)
  self.class.k(max: 3)
  ... visit(*) ... # unbounded recursion
end
```

I don't know whether this has to be merged. It is basically a shortcut for something like:

```
def visit(*)
  a{ @max_calls ||= 0; @max_calls += 1; @max_calls <= 3 }
  ... visit(*) ... # unbounded recursion
end
```
