### PR TITLE
Add letters/clean, a utility to trace Letters uses

### DIFF
--- a/lib/letters/clean.rb
+++ b/lib/letters/clean.rb
@@ -18,6 +18,6 @@ end
 
 at_exit{
   require 'awesome_print'
-  ap "Letters were used at:", color: {:string => :red}
+  ap "Letters were used at:", color: {:string => :blue}
   ap Letters.uses.to_a
 }

--- a/lib/letters/clean.rb
+++ b/lib/letters/clean.rb
@@ -17,6 +17,7 @@ module Letters
 end
 
 at_exit{
+  require 'awesome_print'
   ap "Letters were used at:", color: {:string => :red}
   ap Letters.uses.to_a
 }

--- a/lib/letters/clean.rb
+++ b/lib/letters/clean.rb
@@ -1,0 +1,22 @@
+require 'letters'
+require 'set'
+module Letters
+
+  def self.uses
+    @@letters_usage ||= Set.new
+  end
+
+  module CoreExt
+
+    def letters_tap(&bl)
+      Letters.uses << caller[1]
+      tap(&bl)
+    end
+
+  end
+end
+
+at_exit{
+  ap "Letters were used at:", color: {:string => :red}
+  ap Letters.uses.to_a
+}

--- a/lib/letters/core_ext.rb
+++ b/lib/letters/core_ext.rb
@@ -9,10 +9,12 @@ module Letters
   module CoreExt
     DELIM = "-" * 20
 
+    alias_method :letters_tap, :tap
+
     # Assert
     def a(opts={}, &block)
       opts = { error_class: AssertionError }.merge opts
-      tap do |o|
+      letters_tap do |o|
         Helpers.message opts
         if block_given? && !o.instance_eval(&block)
           raise opts[:error_class]
@@ -22,14 +24,14 @@ module Letters
 
     # Beep
     def b
-      tap do
+      letters_tap do
         $stdout.print "\a"
       end
     end
 
     # Callstack
     def c(opts={})
-      tap do
+      letters_tap do
         Helpers.message opts
         Helpers.out caller(4), opts
       end
@@ -37,14 +39,14 @@ module Letters
 
     # Debug
     def d
-      tap do
+      letters_tap do
         Helpers.call_debugger 
       end
     end
 
     # Diff 1
     def d1
-      tap do |o|
+      letters_tap do |o|
         Letters.object_for_diff = o
       end
     end
@@ -53,7 +55,7 @@ module Letters
     def d2(opts={})
       require "awesome_print"
       opts = { format: "ap" }.merge opts
-      tap do |o|
+      letters_tap do |o|
         diff = Helpers.diff(Letters.object_for_diff, o)
         Helpers.message opts
         Helpers.out diff, opts
@@ -64,7 +66,7 @@ module Letters
     # Empty check
     def e(opts={})
       opts.merge! :error_class => EmptyError
-      tap do |o|
+      letters_tap do |o|
         Helpers.message opts
         o.a(opts) { !empty? } 
       end
@@ -73,7 +75,7 @@ module Letters
     # File
     def f(opts={})
       opts = { format: "yaml", name: "log" }.merge opts
-      tap do |o|
+      letters_tap do |o|
         suffixes = [""] + (1..50).to_a
         deduper = suffixes.detect {|x| !File.directory? "#{opts[:name]}#{x}" }
 
@@ -88,7 +90,7 @@ module Letters
 
     # Jump
     def j(&block)
-      tap do |o|
+      letters_tap do |o|
         o.instance_eval &block
       end
     end
@@ -96,7 +98,7 @@ module Letters
     # Log
     def l(opts={})
       opts = { level: "info", format: "yaml" }.merge opts
-      tap do |o|
+      letters_tap do |o|
         begin
           logger.send(opts[:level], opts[:message]) if opts[:message]
           logger.send(opts[:level], Helpers.send(opts[:format], o))
@@ -108,7 +110,7 @@ module Letters
 
     # Taint and untaint object
     def m(taint=true)
-      tap do |o|
+      letters_tap do |o|
         if taint
           o.taint
         else
@@ -120,7 +122,7 @@ module Letters
     # Nil check
     def n(opts={})
       opts.merge! :error_class => NilError
-      tap do |o|
+      letters_tap do |o|
         o.a(opts) { !nil? } 
       end
     end
@@ -128,7 +130,7 @@ module Letters
     # Print to STDOUT
     def o(opts={}, &block)
       opts = { format: "ap", stream: $stdout }.merge opts
-      tap do |o|
+      letters_tap do |o|
         Helpers.message opts
         obj = block_given? ? o.instance_eval(&block) : o 
         Helpers.out obj, opts
@@ -137,7 +139,7 @@ module Letters
 
     # RI
     def r(method=nil)
-      tap do |o|
+      letters_tap do |o|
         method_or_empty = method ? "##{method}" : method
         system "ri #{o.class}#{method_or_empty}" 
       end
@@ -145,7 +147,7 @@ module Letters
 
     # Change safety level
     def s(level=nil)
-      tap do
+      letters_tap do
         level ||= $SAFE + 1
         Helpers.change_safety level
       end
@@ -154,7 +156,7 @@ module Letters
     # Timestamp
     def t(opts={})
       opts = { time_format: "millis" }.merge opts
-      tap do
+      letters_tap do
         Helpers.message opts
         Helpers.out Time.now.to_s(opts[:time_format].to_sym), opts
       end


### PR DESCRIPTION
When debugging is not trivial, you end up putting letters here and there. How do you list all calls to letters for cleaning them?

```
require 'letters/clean'
```

Ok, I confess, `git reset --hard` and a better test coverage works nice as well ;-)
