### PR TITLE
Use Ruby's built-in debugger.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,3 @@ gem "activesupport"
 gem "xml-simple"
 gem "timecop"
 gem "colorize"
-
-if RUBY_VERSION =~ /1\.9\.\d+/
-  gem "debugger"
-else
-  gem "ruby-debug"
-end

--- a/letters.gemspec
+++ b/letters.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport"
   s.add_dependency "xml-simple"
   s.add_dependency "colorize"
-  s.add_dependency "debugger"
 
   s.add_development_dependency "timecop"
   s.add_development_dependency "rspec"

--- a/lib/letters/helpers.rb
+++ b/lib/letters/helpers.rb
@@ -98,8 +98,13 @@ module Letters
 
     # This provides a mockable method for testing
     def self.call_debugger
-      require "ruby-debug"
-      debugger
+      if (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx')
+        require 'rubinius/debugger'
+        Rubinius::Debugger.start
+      else
+        require 'debug'
+      end
+
       nil
     end
 


### PR DESCRIPTION
- require 'debug' for MRI/JRuby.
- require 'rubinius/debugger' and Rubinius::Debugger.start for Rubinius.
